### PR TITLE
Add missing links to standards catalogue

### DIFF
--- a/Standards_Catalogue.md
+++ b/Standards_Catalogue.md
@@ -2,6 +2,7 @@
 
 ## [End User Compute (EUC)](./euc) - desktop and mobile
 
+* [Standards for Desktop EUC devices](./euc/desktop-devices.md)
 * [Windows 10 Standard Applications](./euc/windows-10-standard-apps.md)
 
 ## [Identity Management](./identity-management)
@@ -16,8 +17,8 @@
 
 ## Other Applicable UK Government and NHS Standards
 
-* [NHS Service Manual]
-* [GDS Design Manual]
-* [Tech Code of Practice]
+* [NHS Service Manual](https://service-manual.nhs.uk)
+* [GDS Service Manual](https://www.gov.uk/service-manual)
+* [Tech Code of Practice](https://www.gov.uk/government/publications/technology-code-of-practice)
 * The UK Government **[Tech Vision](https://www.gov.uk/government/publications/the-future-of-healthcare-our-vision-for-digital-data-and-technology-in-health-and-care/the-future-of-healthcare-our-vision-for-digital-data-and-technology-in-health-and-care)** - ‘Standards that meet user needs: we must be clear how these standards address the user needs of people who use health and care services, carers and families, as well as care professionals and commissioners.’
-* The **[NHS Long Term Plan](https://www.longtermplan.nhs.uk/areas-of-work/digital-transformation/)** - ‘Set standards that keep information secure and make sure NHS IT systems talk to each other to provide health and care staff with complete access to joined up patient records.’​
+* The **[NHS Long Term Plan](https://www.longtermplan.nhs.uk/areas-of-work/digital-transformation/)** - ‘Set standards that keep information secure and make sure NHS IT systems talk to each other to provide health and care staff with complete access to joined up patient records.’


### PR DESCRIPTION
I noticed missing links in the standards catalogue and added them to the best of my knowledge.

I was unsure if GDS Design Manual should link to the GDS Service Manual, the [Design System](https://design-system.service.gov.uk/) or something else I'm unaware of. Happy to change if I made the wrong assumption.